### PR TITLE
Fix typo

### DIFF
--- a/Part2/doc/Problem3.tex
+++ b/Part2/doc/Problem3.tex
@@ -58,7 +58,7 @@ The goal of this problem is to exploit the power of the recommended tools rather
 
 \vspace{2mm}
 
-  After applying {\tt prover9 -f part2\_3a.in}, we found that the first 3 properties are proved, but the fourth one, which implies the property of commutativity, is failed. In order to determine the size of the smallest finite group for which it does not hold, we apply {\tt mace4 part$2\_3a$.in} to find the smallest noncommutative group by finding the conterexample to the statement that all groups are commutative. {\tt mace4} exits with 1 model. The model is as follows.
+  After applying {\tt prover9 -f part2\_3a.in}, we found that the first 3 properties are proved, but the fourth one, which implies the property of commutativity, is failed. In order to determine the size of the smallest finite group for which it does not hold, we apply {\tt mace4 part$2\_3a$.in} to find the smallest noncommutative group by finding the counterexample to the statement that all groups are commutative. {\tt mace4} exits with 1 model. The model is as follows.
 
 \vspace{3mm}
 


### PR DESCRIPTION
The word 'counterexample' was spelled wrong.
